### PR TITLE
issue with old node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.5-fpm-alpine
+FROM php:7.2.10-fpm-alpine
 
 LABEL maintainer="Tauno Hogue <tauno@thinkshout.com>"
 


### PR DESCRIPTION
These errors appeared, looks like we were on node version 6. This change seems to fix it for FIPA.
```
ERROR in ./js/main.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
/var/www/html/financial-planning-association/web/themes/custom/ts_fipa/node_modules/schema-utils/dist/util/hints.js:16
  const currentSchema = { ...schema
                          ^^^
SyntaxError: Unexpected token ...
```
and
```
npm ERR! Linux 5.3.0-1017-aws
npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "run" "build"
npm ERR! node v6.10.3
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! ts_fipa@1.0.0 build: `webpack --config webpack.config.js`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the ts_fipa@1.0.0 build script 'webpack --config webpack.config.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the ts_fipa package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     webpack --config webpack.config.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs ts_fipa
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls ts_fipa
npm ERR! There is likely additional logging output above.
npm ERR! Please include the following file with any support request:
npm ERR!     /var/www/html/financial-planning-association/web/themes/custom/ts_fipa/npm-debug.log
Exited with code exit status 1
```